### PR TITLE
Simplify bridge.php by removing unnecessary code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ lint:
 .PHONY: unit_test
 unit_test:
 	php $(build_tools_directory)/composer.phar install --prefer-dist
-	vendor/bin/phpunit -c tests/phpunit.xml --testdox
+	vendor/bin/phpunit tests/ --testdox
 
 # Build a ZIP for deploying
 .PHONY: zip

--- a/bridge.php
+++ b/bridge.php
@@ -1,244 +1,121 @@
 <?php
+// Parts of this file are based on index.php (Roundcube version 1.4.8).
+// TODO Reduce amount of duplicate code from index.php. We may be able to do that by:
+//  * removing authenticate hook logic using $_POST.
+//  * moving login logic to a function provided by base Roundcube
 
-/* Copied and edited code from index.php (Roundcube version 1.4.8) */
 // include environment
 require_once __DIR__ . '/../../program/include/iniset.php';
 
 // init application, start session, init output class, etc.
 $RCMAIL = rcmail::get_instance(0, $GLOBALS['env']);
 
-// Make the whole PHP output non-cacheable (#1487797)
-$RCMAIL->output->nocacheing_headers();
-$RCMAIL->output->common_headers(!empty($_SESSION['user_id']));
+/// Auth hack BEGIN
+// TODO authenticate hook may actually be removed. Unclear if this is required for cPanel auth.
+// Set some global POST vars that would be usually set via HTML <input> tags are:
+// _task, _action, _timezone, _user, _pass, _token . We set all except for token.
+// Token should only be required for an existing session. Also disregarding Timezone for now
+$_POST['_user'] = $_SERVER['PHP_AUTH_USER'];
+$_POST['_pass'] = $_SERVER['PHP_AUTH_PW'];
+$_POST['_action'] = 'login';
+$_POST['_task'] = 'login';
 
-// turn on output buffering
-ob_start();
+/// Impersonation / admin auth BEGIN
+// An array to store the admin user, as well the user-to-impersonate
+// (in case of admin auth)
+$users = [];
 
-// check if config files had errors
-if ($err_str = $RCMAIL->config->get_error()) {
-    rcmail::raise_error(array(
-        'code' => 601,
-        'type' => 'php',
-        'message' => $err_str), false, true);
+// Check if we're dealing with admin auth credentials
+// and if yes, then take the first part as the admin username
+// to use for login
+if (mb_strpos($_POST['_user'], "*")) {
+    $users = explode("*", $_POST['_user']);
+    $_POST['_user'] = $users[0];
 }
+/// Impersonation / admin auth END
 
-// check DB connections and exit on failure
-if ($err_str = $RCMAIL->db->is_error()) {
-    rcmail::raise_error(array(
-        'code' => 603,
-        'type' => 'db',
-        'message' => $err_str), false, true);
-}
+$pass_charset  = $RCMAIL->config->get('password_charset', 'UTF-8');
 
-// error steps
-// OpenXPort: Task is always assumed to be login
-// Removed
+$auth = $RCMAIL->plugins->exec_hook('authenticate', array(
+    'host'  => $RCMAIL->autoselect_host(),
+    'user'  => trim(rcube_utils::get_input_value('_user', rcube_utils::INPUT_POST)),
+    'pass'  => rcube_utils::get_input_value('_pass', rcube_utils::INPUT_POST, true, $pass_charset),
+    'valid' => true, //  It is always valid in Karlsruhe!
+    'cookiecheck' => false, // No cookies for you in Karlsruhe!
+));
+/// Auth hack END
 
-// check if https is required (for login) and redirect if necessary
-// OpenXPort: TODO does that make sense?
-if (empty($_SESSION['user_id']) && ($force_https = $RCMAIL->config->get('force_https', false))) {
-    // force_https can be true, <hostname>, <hostname>:<port>, <port>
-    if (!is_bool($force_https)) {
-        list($host, $port) = explode(':', $force_https);
+// Login
+// TODO The following contains quite a lot of duplicate code from RC's index.php.
+//   It may be moved to an own function (except for returning errors via API)?
+if (
+    $auth['valid'] && !$auth['abort']
+    && $RCMAIL->login($auth['user'], $auth['pass'], $auth['host'], $auth['cookiecheck'])
+) {
+    $logger->info("Successfully logged in as " . $auth['user']);
 
-        if (is_numeric($host) && empty($port)) {
-            $port = $host;
-            $host = '';
-        }
-    }
-
-    if (!rcube_utils::https_check($port ?: 443)) {
-        if (empty($host)) {
-            $host = preg_replace('/:[0-9]+$/', '', $_SERVER['HTTP_HOST']);
-        }
-        if ($port && $port != 443) {
-            $host .= ':' . $port;
-        }
-
-        header('Location: https://' . $host . $_SERVER['REQUEST_URI']);
-        exit;
-    }
-}
-
-// trigger startup plugin hook
-$startup = $RCMAIL->plugins->exec_hook('startup', array('task' => $RCMAIL->task, 'action' => $RCMAIL->action));
-$RCMAIL->set_task($startup['task']);
-$RCMAIL->action = $startup['action'];
-
-// try to log in
-if (true) { // OpenXPort: Task is always assumed to be login
-    $request_valid = true; // OpenXPort: It is always valid in Karlsruhe!
-    $pass_charset  = $RCMAIL->config->get('password_charset', 'UTF-8');
-
-    // purge the session in case of new login when a session already exists
-    // OpenXPort: Disregard Session
-    // Removed
-
-    // OpenXPort: Auth hack
-    // Set some global POST vars that would be usually set via HTML <input> tags are:
-    // _task, _action, _timezone, _user, _pass, _token . We set all except for token.
-    // Token should only be required for an existing session.
-    // Disregarding Timezone for now
-    $_POST['_user'] = $_SERVER['PHP_AUTH_USER'];
-    $_POST['_pass'] = $_SERVER['PHP_AUTH_PW'];
-    $_POST['_action'] = 'login';
-    $_POST['_task'] = 'login';
-
-    // An array to store the admin user, as well the user-to-impersonate
-    // (in case of admin auth)
-    $users = [];
-
-    // Check if we're dealing with admin auth credentials
-    // and if yes, then take the first part as the admin username
-    // to use for login
-    if (mb_strpos($_POST['_user'], "*")) {
-        $users = explode("*", $_POST['_user']);
-        $_POST['_user'] = $users[0];
-    }
-
-    $auth = $RCMAIL->plugins->exec_hook('authenticate', array(
-            'host'  => $RCMAIL->autoselect_host(),
-            'user'  => trim(rcube_utils::get_input_value('_user', rcube_utils::INPUT_POST)),
-            'pass'  => rcube_utils::get_input_value('_pass', rcube_utils::INPUT_POST, true, $pass_charset),
-            'valid' => $request_valid,
-            'cookiecheck' => false, // OpenXPort: No cookies for you in Karlsruhe!
-    ));
-
-    // Login
-    if (
-        $auth['valid'] && !$auth['abort']
-        && $RCMAIL->login($auth['user'], $auth['pass'], $auth['host'], $auth['cookiecheck'])
-    ) {
-        // create new session ID, don't destroy the current session
-        // it was destroyed already by $RCMAIL->kill_session() above
-        // OpenXPort: Disregard Session
-        // Removed
-
-        $logger->info("Successfully logged in as " . $auth['user']);
-
-        // log successful login
-        $RCMAIL->log_login();
-
-        // restore original request parameters
-        // OpenXPort: Task is always assumed to be login
-        // Removed
-
-        // allow plugins to control the redirect url after login success
-        // OpenXPort: Task is always assumed to be login
-        // Removed
-
-        // send redirect
-        // OpenXPort: Task is always assumed to be login
-        // Removed
+    // log successful login
+    $RCMAIL->log_login();
+} else {
+    if (!$auth['valid']) {
+        $error_code = rcmail::ERROR_INVALID_REQUEST;
     } else {
-        if (!$auth['valid']) {
-            $error_code = rcmail::ERROR_INVALID_REQUEST;
-        } else {
-            $error_code = is_numeric($auth['error']) ? $auth['error'] : $RCMAIL->login_error();
-        }
-
-        $error_labels = array(
-            rcmail::ERROR_STORAGE          => 'storageerror',
-            rcmail::ERROR_COOKIES_DISABLED => 'cookiesdisabled',
-            rcmail::ERROR_INVALID_REQUEST  => 'invalidrequest',
-            rcmail::ERROR_INVALID_HOST     => 'invalidhost',
-            rcmail::ERROR_RATE_LIMIT       => 'accountlocked',
-        );
-
-        $error_message = !empty($auth['error']) && !is_numeric($auth['error'])
-            ? $auth['error'] : ($error_labels[$error_code] ?: 'loginfailed');
-
-        // OpenXPort: We do our own presentation
-        // Removed
-
-        // log failed login
-        $RCMAIL->log_login($auth['user'], true, $error_code);
-
-        $logger->error("Failed log in for " . $auth['user'] . " error message is " . $error_message);
-
-        // OpenXPort: Return auth error via API
-        $loginError = null;
-
-        // OpenXPort: TODO use http_response_code() once we move that to generic lib.
-        switch ($error_code) {
-            case rcmail::ERROR_RATE_LIMIT:
-                $loginError = 'urn:ietf:params:jmap:error:limit';
-                header('HTTP/1.0 429 Too Many Requests');
-                break;
-            case rcmail::ERROR_INVALID_REQUEST:
-                $loginError = 'urn:ietf:params:jmap:error:notRequest';
-                header('HTTP/1.0 400 Bad Request');
-                break;
-            default:
-                $loginError = '401 Unauthorized';
-                header('HTTP/1.0 401 Unauthorized');
-        }
-
-        die($loginError);
-
-        $RCMAIL->plugins->exec_hook('login_failed', array(
-            'code' => $error_code, 'host' => $auth['host'], 'user' => $auth['user']));
-
-        if (!isset($_SESSION['user_id'])) {
-            $RCMAIL->kill_session();
-        }
+        $error_code = is_numeric($auth['error']) ? $auth['error'] : $RCMAIL->login_error();
     }
 
-    // Obtain the username of the user that we want to act on behalf of
-    if (isset($users[1]) && !empty($users[1])) {
-        if (!in_array($users[0], $oxpConfig["adminUsers"])) {
-            http_response_code(403);
-            die("403 Forbidden");
-        }
+    $error_labels = array(
+        rcmail::ERROR_STORAGE          => 'storageerror',
+        rcmail::ERROR_COOKIES_DISABLED => 'cookiesdisabled',
+        rcmail::ERROR_INVALID_REQUEST  => 'invalidrequest',
+        rcmail::ERROR_INVALID_HOST     => 'invalidhost',
+        rcmail::ERROR_RATE_LIMIT       => 'accountlocked',
+    );
 
-        // Try to get the user that corresponds to this username via the rcube_user::query() method
-        // Since query() requires the user's domain as the second parameter, we take the domain of the logged-in user
-        // (in admin auth scenario, that is the admin user). We assume for admin auth that both admin
-        // and user-acted-on-behalf-of share the same domain
-        $userDomain = $RCMAIL->user->get_username('domain');
-        $userToSetAsCurrentUser = rcube_user::query($users[1], $userDomain);
+    $error_message = !empty($auth['error']) && !is_numeric($auth['error'])
+        ? $auth['error'] : ($error_labels[$error_code] ?: 'loginfailed');
 
-        // If we managed to get this user, then we set this user as the current user within Roundcube via set_user()
-        if (isset($userToSetAsCurrentUser) && !empty($userToSetAsCurrentUser)) {
-            $RCMAIL->set_user($userToSetAsCurrentUser);
-        }
+    // log failed login
+    $RCMAIL->log_login($auth['user'], true, $error_code);
+
+    $logger->error("Failed log in for " . $auth['user'] . " error message is " . $error_message);
+
+    // Return auth error via API
+    $loginError = null;
+
+    switch ($error_code) {
+        case rcmail::ERROR_RATE_LIMIT:
+            $loginError = 'urn:ietf:params:jmap:error:limit';
+            header('HTTP/1.0 429 Too Many Requests');
+            break;
+        case rcmail::ERROR_INVALID_REQUEST:
+            $loginError = 'urn:ietf:params:jmap:error:notRequest';
+            header('HTTP/1.0 400 Bad Request');
+            break;
+        default:
+            $loginError = '401 Unauthorized';
+            header('HTTP/1.0 401 Unauthorized');
+    }
+
+    die($loginError);
+}
+
+/// Impersonation / admin auth APPENDIX
+// Obtain the username of the user that we want to act on behalf of
+if (isset($users[1]) && !empty($users[1])) {
+    if (!in_array($users[0], $oxpConfig["adminUsers"])) {
+        http_response_code(403);
+        die("403 Forbidden");
+    }
+
+    // Try to get the user that corresponds to this username via the rcube_user::query() method
+    // Since query() requires the user's domain as the second parameter, we take the domain of the logged-in user
+    // (in admin auth scenario, that is the admin user). We assume for admin auth that both admin
+    // and user-acted-on-behalf-of share the same domain
+    $userDomain = $RCMAIL->user->get_username('domain');
+    $userToSetAsCurrentUser = rcube_user::query($users[1], $userDomain);
+
+    // If we managed to get this user, then we set this user as the current user within Roundcube via set_user()
+    if (isset($userToSetAsCurrentUser) && !empty($userToSetAsCurrentUser)) {
+        $RCMAIL->set_user($userToSetAsCurrentUser);
     }
 }
-
-// end session
-// OpenXPort: Task is always assumed to be login
-// Removed
-
-// check session and auth cookie
-// OpenXPort: Task is always assumed to be login
-// Removed
-
-// not logged in -> show login page
-// OpenXPort: Task is always assumed to be login
-// Removed
-
-// we're ready, user is authenticated and the request is safe
-$plugin = $RCMAIL->plugins->exec_hook('ready', array('task' => $RCMAIL->task, 'action' => $RCMAIL->action));
-$RCMAIL->set_task($plugin['task']);
-$RCMAIL->action = $plugin['action'];
-
-// handle special actions
-// OpenXPort: Task is always assumed to be login
-// Removed
-
-
-// include task specific functions
-if (is_file($incfile = INSTALL_PATH . 'program/steps/' . $RCMAIL->task . '/func.inc')) {
-    include_once $incfile;
-}
-
-// allow 5 "redirects" to another action
-// OpenXPort: Task is always assumed to be login
-// Removed
-
-// OpenXPort: Task is always assumed to be login
-// Removed
-
-// parse main template (default)
-// OpenXPort: We do our own presentation
-// Removed

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ec51a64217ef908dab6dfcecb85ff6c",
+    "content-hash": "7b9f4e6b9fd0df3702f89cb9aaeec930",
     "packages": [
         {
             "name": "audriga/jmap-icalendar_vcard",
-            "version": "0.4.0",
+            "version": "0.5.0",
             "source": {
                 "type": "git",
-                "url": "git@bitbucket.org:audriga/jmap-php-icalendar_vcard.git",
-                "reference": "bd9f6fb5097e56774a0f53611f61729e13a6c55a"
+                "url": "https://github.com/audriga/jmap-php-icalendar_vcard.git",
+                "reference": "990379f6d8378cfffb839cd87648b65b6b4eecc6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/audriga/jmap-php-icalendar_vcard/zipball/990379f6d8378cfffb839cd87648b65b6b4eecc6",
+                "reference": "990379f6d8378cfffb839cd87648b65b6b4eecc6",
+                "shasum": ""
             },
             "require": {
                 "audriga/jmap-openxport": "~1",
@@ -34,13 +40,7 @@
                     "src/"
                 ]
             },
-            "archive": {
-                "exclude": [
-                    "/tests",
-                    "/build",
-                    "/README.md"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -60,15 +60,25 @@
                 "groupware",
                 "jmap"
             ],
-            "time": "2023-09-26T08:21:56+00:00"
+            "support": {
+                "issues": "https://github.com/audriga/jmap-php-icalendar_vcard/issues",
+                "source": "https://github.com/audriga/jmap-php-icalendar_vcard/tree/0.5.0"
+            },
+            "time": "2024-01-11T12:55:56+00:00"
         },
         {
             "name": "audriga/jmap-openxport",
-            "version": "1.7.1",
+            "version": "1.7.2",
             "source": {
                 "type": "git",
-                "url": "git@bitbucket.org:audriga/jmap-php-openxport.git",
-                "reference": "04aff53b8229087650f32e24f51af5659065d793"
+                "url": "https://github.com/audriga/openxport-jmap.git",
+                "reference": "e070b3a592b6c2c1822d3673788a5af2cb7f6c58"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/audriga/openxport-jmap/zipball/e070b3a592b6c2c1822d3673788a5af2cb7f6c58",
+                "reference": "e070b3a592b6c2c1822d3673788a5af2cb7f6c58",
+                "shasum": ""
             },
             "require": {
                 "php": ">=5.6",
@@ -89,6 +99,7 @@
                     "src/"
                 ]
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -110,7 +121,11 @@
                 "jmap",
                 "migration"
             ],
-            "time": "2023-08-21T09:31:07+00:00"
+            "support": {
+                "issues": "https://github.com/audriga/openxport-jmap/issues",
+                "source": "https://github.com/audriga/openxport-jmap/tree/1.7.2"
+            },
+            "time": "2024-01-11T12:47:38+00:00"
         },
         {
             "name": "psr/log",
@@ -224,16 +239,16 @@
         },
         {
             "name": "sabre/vobject",
-            "version": "4.5.3",
+            "version": "4.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/vobject.git",
-                "reference": "fe6d9183154ed6f2f913f2b568d3d51d8ae9b308"
+                "reference": "a6d53a3e5bec85ed3dd78868b7de0f5b4e12f772"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/vobject/zipball/fe6d9183154ed6f2f913f2b568d3d51d8ae9b308",
-                "reference": "fe6d9183154ed6f2f913f2b568d3d51d8ae9b308",
+                "url": "https://api.github.com/repos/sabre-io/vobject/zipball/a6d53a3e5bec85ed3dd78868b7de0f5b4e12f772",
+                "reference": "a6d53a3e5bec85ed3dd78868b7de0f5b4e12f772",
                 "shasum": ""
             },
             "require": {
@@ -324,20 +339,20 @@
                 "issues": "https://github.com/sabre-io/vobject/issues",
                 "source": "https://github.com/fruux/sabre-vobject"
             },
-            "time": "2023-01-22T12:21:50+00:00"
+            "time": "2023-11-09T12:54:37+00:00"
         },
         {
             "name": "sabre/xml",
-            "version": "4.0.2",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/xml.git",
-                "reference": "61a44c39f51e386ae495304bfb78f0b0a6ed11fe"
+                "reference": "99caa5dd248776ca6a1e1d2cfdef556a3fa63456"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/xml/zipball/61a44c39f51e386ae495304bfb78f0b0a6ed11fe",
-                "reference": "61a44c39f51e386ae495304bfb78f0b0a6ed11fe",
+                "url": "https://api.github.com/repos/sabre-io/xml/zipball/99caa5dd248776ca6a1e1d2cfdef556a3fa63456",
+                "reference": "99caa5dd248776ca6a1e1d2cfdef556a3fa63456",
                 "shasum": ""
             },
             "require": {
@@ -349,7 +364,7 @@
                 "sabre/uri": ">=2.0,<4.0.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.20",
+                "friendsofphp/php-cs-fixer": "^3.38",
                 "phpstan/phpstan": "^1.10",
                 "phpunit/phpunit": "^9.6"
             },
@@ -393,7 +408,7 @@
                 "issues": "https://github.com/sabre-io/xml/issues",
                 "source": "https://github.com/fruux/sabre-xml"
             },
-            "time": "2023-06-28T14:18:46+00:00"
+            "time": "2023-11-09T10:47:15+00:00"
         }
     ],
     "packages-dev": [
@@ -458,25 +473,27 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.17.1",
+            "version": "v5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
+                "reference": "2218c2252c874a4624ab2f613d86ac32d227bc69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/2218c2252c874a4624ab2f613d86ac32d227bc69",
+                "reference": "2218c2252c874a4624ab2f613d86ac32d227bc69",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -484,7 +501,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -508,9 +525,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.1"
             },
-            "time": "2023-08-13T19:53:39+00:00"
+            "time": "2024-02-21T19:24:10+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -625,23 +642,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.7",
+            "version": "10.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "355324ca4980b8916c18b9db29f3ef484078f26e"
+                "reference": "78c3b7625965c2513ee96569a4dbb62601784145"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/355324ca4980b8916c18b9db29f3ef484078f26e",
-                "reference": "355324ca4980b8916c18b9db29f3ef484078f26e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/78c3b7625965c2513ee96569a4dbb62601784145",
+                "reference": "78c3b7625965c2513ee96569a4dbb62601784145",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=8.1",
                 "phpunit/php-file-iterator": "^4.0",
                 "phpunit/php-text-template": "^3.0",
@@ -691,7 +708,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.7"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.11"
             },
             "funding": [
                 {
@@ -699,7 +716,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-04T15:34:17+00:00"
+            "time": "2023-12-21T15:38:30+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -946,16 +963,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.4.2",
+            "version": "10.5.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "cacd8b9dd224efa8eb28beb69004126c7ca1a1a1"
+                "reference": "0d968f6323deb3dbfeba5bfd4929b9415eb7a9a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/cacd8b9dd224efa8eb28beb69004126c7ca1a1a1",
-                "reference": "cacd8b9dd224efa8eb28beb69004126c7ca1a1a1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0d968f6323deb3dbfeba5bfd4929b9415eb7a9a4",
+                "reference": "0d968f6323deb3dbfeba5bfd4929b9415eb7a9a4",
                 "shasum": ""
             },
             "require": {
@@ -995,7 +1012,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.4-dev"
+                    "dev-main": "10.5-dev"
                 }
             },
             "autoload": {
@@ -1027,7 +1044,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.4.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.11"
             },
             "funding": [
                 {
@@ -1043,7 +1060,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-26T07:21:45+00:00"
+            "time": "2024-02-25T14:05:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1291,20 +1308,20 @@
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "68cfb347a44871f01e33ab0ef8215966432f6957"
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68cfb347a44871f01e33ab0ef8215966432f6957",
-                "reference": "68cfb347a44871f01e33ab0ef8215966432f6957",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.10",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=8.1"
             },
             "require-dev": {
@@ -1313,7 +1330,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.1-dev"
+                    "dev-main": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1337,7 +1354,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.1.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
             },
             "funding": [
                 {
@@ -1345,20 +1362,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-28T11:50:59+00:00"
+            "time": "2023-12-21T08:37:17+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.0.3",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b"
+                "reference": "fbf413a49e54f6b9b17e12d900ac7f6101591b7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/fbf413a49e54f6b9b17e12d900ac7f6101591b7f",
+                "reference": "fbf413a49e54f6b9b17e12d900ac7f6101591b7f",
                 "shasum": ""
             },
             "require": {
@@ -1371,7 +1388,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -1404,7 +1421,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.0"
             },
             "funding": [
                 {
@@ -1412,7 +1429,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-01T07:48:21+00:00"
+            "time": "2023-12-22T10:55:06+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1620,20 +1637,20 @@
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "649e40d279e243d985aa8fb6e74dd5bb28dc185d"
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/649e40d279e243d985aa8fb6e74dd5bb28dc185d",
-                "reference": "649e40d279e243d985aa8fb6e74dd5bb28dc185d",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.10",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=8.1"
             },
             "require-dev": {
@@ -1666,7 +1683,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.1"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
             },
             "funding": [
                 {
@@ -1674,7 +1691,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T09:25:50+00:00"
+            "time": "2023-12-21T08:38:20+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1962,16 +1979,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
+                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
                 "shasum": ""
             },
             "require": {
@@ -1981,11 +1998,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -2000,35 +2017,58 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards",
                 "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
-            "time": "2023-02-22T23:07:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-02-16T15:06:51+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
                 "shasum": ""
             },
             "require": {
@@ -2057,7 +2097,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
             },
             "funding": [
                 {
@@ -2065,7 +2105,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2023-11-20T00:12:19+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
Removes a bunch of code from bridge.php

IIRC we kept most of the code, because we were unsure about consequences of removing it. However, after looking at what Kolab's freebusy plugin [1] does and letting our Roundcube plugin mature more and more, we should be safely able to remove unnecessary code.

[1]: https://git.kolab.org/source/freebusy

**Test Status**: Ran integration tests of OXP Core and our internal client to verify it still works.